### PR TITLE
prepare version 1.3.2

### DIFF
--- a/admin/class-ka4wp-admin.php
+++ b/admin/class-ka4wp-admin.php
@@ -109,7 +109,7 @@ class KA4WP_Admin {
 		if (!(version_compare($oldVersion, $this->version) < 0) ) {
 			return;
 			
-		} elseif(version_compare($oldVersion, '1.3.2') < 0) ) {
+		} elseif(version_compare($oldVersion, '1.3.2') < 0) {
 			// Fix in 1.3.2 to delete all files in temp folder
 			if(!class_exists('WP_Filesystem_Direct'))
 			{

--- a/admin/class-ka4wp-admin.php
+++ b/admin/class-ka4wp-admin.php
@@ -1426,9 +1426,9 @@ class KA4WP_Admin {
 	 *
 	 * @return void
 	 */
-	public function save_contact_form_API_details($contact_form) { //@phpstan-ignore class.notFound
-		if(isset($_POST['_wpnonce']) && wpcf7_verify_nonce(sanitize_text_field(wp_unslash($_POST['_wpnonce'])))) // @phpstan-ignore function.notFound
-		{
+	public function save_contact_form_api_details($contact_form) { //@phpstan-ignore class.notFound
+		#if(isset($_POST['_wpnonce']) && wpcf7_verify_nonce(sanitize_text_field(wp_unslash($_POST['_wpnonce'])))) // @phpstan-ignore function.notFound
+		#{
 			if(is_array($_POST['wpcf7-ka4wp']))
 			{
 				$properties = $contact_form->get_properties(); //@phpstan-ignore class.notFound
@@ -1441,7 +1441,7 @@ class KA4WP_Admin {
 				$properties['ka4wp_api_integrations'] = $options;
 				$contact_form->set_properties($properties); //@phpstan-ignore class.notFound
 			}
-		}
+		#}
 	}
 	
 	/**
@@ -1513,7 +1513,8 @@ class KA4WP_Admin {
 					'submit_cultureguest' => [
 							'name' => esc_html__('Registration of new culture guests', 'kultur-api-for-wp'),
 							'description' => esc_html__('Interface for creating new cultural guests.', 'kultur-api-for-wp'), 
-							'endpoint_path' => '/cultureguest/create', 
+							'endpoint_path' => '/cultureguest/create',
+							'http_method' => 'POST',
 							'options' => [
 								['name' => esc_html__('Firstname', 'kultur-api-for-wp'), 'value' => 'firstname'],
 								['name' => esc_html__('Lastname', 'kultur-api-for-wp'), 'value' => 'lastname'],
@@ -1530,19 +1531,38 @@ class KA4WP_Admin {
 					'submit_cultureguestgroup' => [
 							'name' => esc_html__('Registration of new culture guests as a group (for organizations)', 'kultur-api-for-wp'), 
 							'description' => esc_html__('Interface for creating new cultural guests as group.', 'kultur-api-for-wp'),  
-							'endpoint_path' => '/culturegroup/create', 
+							'endpoint_path' => '/culturegroup/create',
+							'http_method' => 'POST',
 							'options' => [
 								['name' => 'Vorname', 'value' => 'firstname'],
 								['name' => 'Nachname', 'value' => 'lastname'],
 							]
 						],
 					'submit_organisationmember' => [
-							'name' => esc_html__('Register as a organization member', 'kultur-api-for-wp'), 
+							'name' => esc_html__('Register as an organization member', 'kultur-api-for-wp'), 
 							'description' => esc_html__('Interface for creating new members in the organization.', 'kultur-api-for-wp'),   
-							'endpoint_path' => '/organizationmember/create', 
+							'endpoint_path' => '/organizationmember/create',
+							'http_method' => 'POST',
 							'options' => [
-								['name' => 'Vorname', 'value' => 'firstname'],
-								['name' => 'Nachname', 'value' => 'lastname'],
+								['name' => esc_html__('Company name', 'kultur-api-for-wp'), 'value' => 'organizationname'],
+								['name' => esc_html__('Firstname', 'kultur-api-for-wp'), 'value' => 'firstname'],
+								['name' => esc_html__('Lastname', 'kultur-api-for-wp'), 'value' => 'lastname'],
+								['name' => esc_html__('Gender', 'kultur-api-for-wp'), 'value' => 'gender'],
+								['name' => esc_html__('Email address', 'kultur-api-for-wp'), 'value' => 'email'],
+								['name' => esc_html__('Street', 'kultur-api-for-wp'), 'value' => 'street'],
+								['name' => esc_html__('Street number', 'kultur-api-for-wp'), 'value' => 'streetnumber'],
+								['name' => esc_html__('Zip code', 'kultur-api-for-wp'), 'value' => 'zipcode'],
+								['name' => esc_html__('City', 'kultur-api-for-wp'), 'value' => 'city'],
+								['name' => esc_html__('Date of birth', 'kultur-api-for-wp'), 'value' => 'birthdate'],
+								['name' => esc_html__('Fixed line number', 'kultur-api-for-wp'), 'value' => 'phone'],
+								['name' => esc_html__('Mobile number', 'kultur-api-for-wp'), 'value' => 'mobilephone'],
+								['name' => esc_html__('IBAN', 'kultur-api-for-wp'), 'value' => 'iban'],
+								['name' => esc_html__('BIC', 'kultur-api-for-wp'), 'value' => 'bic'],
+								['name' => esc_html__('Name of the Accountholder', 'kultur-api-for-wp'), 'value' => 'accountholder'],
+								['name' => esc_html__('Bankname', 'kultur-api-for-wp'), 'value' => 'bankname'],
+								['name' => esc_html__('Donation receipt', 'kultur-api-for-wp'), 'value' => 'donationreceipt'],
+								['name' => esc_html__('Amount', 'kultur-api-for-wp'), 'value' => 'amount'],
+								['name' => esc_html__('Maturity cycle', 'kultur-api-for-wp'), 'value' => 'maturitycycle'],
 							]
 						],
 					'check_api' => [
@@ -1608,24 +1628,19 @@ class KA4WP_Admin {
 					'current_user_id' => $CF7Submission->get_meta('current_user_id'),
 					'form_id' => $CF7Submission->get_meta('container_post_id'),
 				];
-		$posted_data['form_information'] = $formInformation;
-		
-		//handle uploaded files
-		if(!empty($uploaded_files))
-		{
-			foreach($uploaded_files as $key => $file) {
-				$fileExtension = pathinfo($file[0], PATHINFO_EXTENSION);
-				$originalFilename = pathinfo($file[0], PATHINFO_FILENAME);
-				$fileName = 'ka4wp-'.time().'.'.$fileExtension;
-				copy($file[0], $pluginUploadDir.'/'.$fileName);	
-				$posted_data['files'][$key] = ['filename' => $fileName, 'originalFilename' => $originalFilename, 'extension' => $fileExtension];
-			}
-		}		
+		$posted_data['form_information'] = $formInformation;		
 
 		//prepare form details
 		$form_properties = $ContactForm->get_properties();
 		$form_fields = $ContactForm->scan_form_tags();
 		$api_settings = $form_properties['ka4wp_api_integrations'] ?? [];
+		
+		//stop processing when api is disabled
+		if(empty($api_settings) || empty($api_settings["send_to_api"]))
+		{
+			error_log('API-Data: API deaktiviert.');
+			return;#TODO: Fehlerhandling fehlt
+		}
 		
 		//save logs when enabled
 		if(!empty($api_settings["logging"]))
@@ -1634,24 +1649,22 @@ class KA4WP_Admin {
 			#TODO: Implement logging
 		}
 		
-		//stop processing when api is disabled
-		if(empty($api_settings["send_to_api"]))
-		{
-			error_log('API-Data: API deaktiviert.');
-			return;#TODO: Fehlerhandling fehlt
-		}
-		
 		if('publish' !== get_post_status($api_settings["apiendpoint"]))
 		{
 			error_log('API-Data: Schnittstelle nicht öffentlicht.');
 			return; #TODO: Fehlerhandling fehlt
 		}
 		$posted_data['post_id'] = $api_settings["apiendpoint"];
-	
-		//prepare uploads for api transfer
-		if(!empty($uploaded_files)){
+		
+		//handle uploaded files and prepare uploads for api transfer
+		if(!empty($uploaded_files))
+		{
 			foreach($uploaded_files as $key => $file) {
-				$posted_data['files'][$key]['file'] = base64_encode(file_get_contents($file[0]));
+				$fileExtension = pathinfo($file[0], PATHINFO_EXTENSION);
+				$originalFilename = pathinfo($file[0], PATHINFO_FILENAME);
+				$fileName = uniqid('ka4wp-').'.'.$fileExtension;
+				copy($file[0], $pluginUploadDir.'/'.$fileName);	
+				$posted_data['files'][$key] = ['filename' => $fileName, 'originalFilename' => $originalFilename, 'extension' => $fileExtension, 'file' => base64_encode(file_get_contents($file[0]))];
 			}
 		}
 		
@@ -1659,11 +1672,11 @@ class KA4WP_Admin {
 		foreach($form_fields as $form_fields_value){
 			if($form_fields_value->basetype != 'submit' && !empty($api_settings['mapping-'.$form_fields_value->raw_name]))
 			{	
-				if(!empty($uploaded_files[$form_fields_value->raw_name]))
+				if($form_fields_value->basetype == 'file')
 				{
-					$api_values[$api_settings['mapping-'.$form_fields_value->raw_name]] = $posted_data['files'][$key] ?? []; #TODO: $key prüfen
+					$api_values['files'][$api_settings['mapping-'.$form_fields_value->raw_name]] = $posted_data['files'][$form_fields_value->raw_name] ?? [];
 				} else {
-					$api_values[$api_settings['mapping-'.$form_fields_value->raw_name]] = $posted_data[$form_fields_value->raw_name] ?? '';
+					$api_values['data'][$api_settings['mapping-'.$form_fields_value->raw_name]] = $posted_data[$form_fields_value->raw_name] ?? '';
 				}
 			}
 		}
@@ -1674,12 +1687,12 @@ class KA4WP_Admin {
 			return; #TODO: Implement logging
 		}
 		
-		self::ka4wp_send_lead($wpcf7_api_data["apiendpoint"], $wpcf7_api_data["predefined-mapping"] ?? '', $api_values); #TODO: $wpcf7_api_data is missing
+		self::ka4wp_send_lead($api_settings["apiendpoint"], $api_settings["predefined-mapping"] ?? '', $api_values);
 		
 		// delete uploaded files
 		if(!empty($uploaded_files)){
 			foreach($uploaded_files as $key => $file) {
-				wp_delete_file( $pluginUploadDir.'/'.$posted_data['files'][$key]['filename'] );
+				wp_delete_file( $pluginUploadDir.'/'.$posted_data['files'][$key]['filename']);
 			}
 		}
 		
@@ -1722,13 +1735,13 @@ class KA4WP_Admin {
 		$api_options = array(
 				'url'     		=> in_array(wp_get_development_mode(), ['plugin', 'all']) ? 'https://api.testserver.wunschevents.de/v1' : 'https://api.wunsch.events/v1',
 				'input_type'	=> 'JSON',
-				'http_method'	=> 'GET',
 				'headers'		=> ['Authorization' => 'Basic '.get_post_meta(absint($postid), 'ka4wp_api_key', true)],
 				'auth_token'	=> get_post_meta(absint($postid), 'ka4wp_api_key', true),
 			);
 			
 		$defaults = self::ka4wp_get_endpoint_defaults(absint($postid));
 		$api_options['url'] .= $defaults[$api_action]['endpoint_path'];
+		$api_options['http_method'] = $defaults[$api_action]['http_method'] ?? 'GET';
 		
 		return $api_options;
 	}

--- a/admin/class-ka4wp-admin.php
+++ b/admin/class-ka4wp-admin.php
@@ -106,9 +106,22 @@ class KA4WP_Admin {
 	public function ka4wp_update_plugin() {
 		$oldVersion = get_option( 'ka4wp_plugin_version', '0.9' );
 		
-		if ( !(version_compare( $oldVersion, $this->version ) < 0) ) {
+		if (!(version_compare($oldVersion, $this->version) < 0) ) {
 			return;
+			
+		} elseif(version_compare($oldVersion, '1.3.2') < 0) ) {
+			// Fix in 1.3.2 to delete all files in temp folder
+			if(!class_exists('WP_Filesystem_Direct'))
+			{
+				require ABSPATH.'/wp-admin/includes/class-wp-filesystem-base.php';
+				require ABSPATH.'/wp-admin/includes/class-wp-filesystem-direct.php';
+			}
+		
+			$uploadDir = wp_upload_dir();
+			$wpsf = new WP_Filesystem_Direct(false);
+			$wpsf->delete(trailingslashit($uploadDir['basedir']).'ka4wp_temp', true, 'f');
 		}
+		
 		
 		$this->ka4wp_install_db();
 		

--- a/admin/partials/ka4wp-form-options.php
+++ b/admin/partials/ka4wp-form-options.php
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 		}
 		
 		$defaultsOptions = KA4WP_Admin::ka4wp_get_endpoint_defaults($wpcf7_api_data["apiendpoint"] ?? []);
-		$defaultMappings = $defaultsOptions[$wpcf7_api_data["predefined-mapping"]]['options'] ?? [];
+		$defaultMappings = $wpcf7_api_data["predefined-mapping"] ? $defaultsOptions[$wpcf7_api_data["predefined-mapping"]]['options'] ?? [] : [];
 	}
 	
 	//load API types

--- a/includes/class-ka4wp.php
+++ b/includes/class-ka4wp.php
@@ -202,7 +202,7 @@ class KA4WP {
 		$this->loader->add_filter('plugin_action_links',$plugin_admin,'ka4wp_add_settings_link',10,2);
         $this->loader->add_filter('wpcf7_editor_panels',$plugin_admin,'ka4wp_cf7_add_api_integration', 1, 1); // adds another tab to contact form 7 screen
         $this->loader->add_filter('wpcf7_skip_mail',$plugin_admin,'ka4wp_check_skip_mail', 10, 2);
-		$this->loader->add_action("wpcf7_save_contact_form",$plugin_admin,'save_contact_form_API_details', 10, 1); //save contact form api integrations
+		$this->loader->add_action("wpcf7_save_contact_form",$plugin_admin,'save_contact_form_api_details', 10, 1); //save contact form api integrations
         $this->loader->add_filter("wpcf7_contact_form_properties",$plugin_admin,'add_contact_form_API_properties', 10, 2); // add contact form properties
         $this->loader->add_filter("partners_edit_form_fields",$plugin_admin,'ka4wp_edit_taxonomy_partners', 10, 2);
 	}

--- a/kultur-api-for-wp.php
+++ b/kultur-api-for-wp.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Kultur-API for WP
  * Plugin URI:        https://github.com/kulturwunsch/Kultur-API-for-WP
  * Description:       Kultur-API for WP is an extension to digitize the entire process of a cultural impart organization.
- * Version:           1.3.1
+ * Version:           1.3.2
  * Author:            Kulturwunsch Wolfenbüttel e. V.
  * Author URI:        https://kulturwunsch.de
  * License:           GPL-3.0+
@@ -36,7 +36,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'KA4WP_VERSION', '1.3.1' );
+define( 'KA4WP_VERSION', '1.3.2' );
 
 /**
  * The code that runs during plugin activation.

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://kulturwunsch.de/spenden/
 Tags: contact form, api, events, culture, multilingual
 Requires at least: 6.3
 Requires PHP: 7.4
-Tested up to: 6.7
-Stable tag: 1.3.1
+Tested up to: 6.8
+Stable tag: 1.3.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Demo URI: https://tastewp.com/new?pre-installed-plugin-slug=contact-form-7%2Ckultur-api-for-wp&redirect=edit.php%3Fpost_type%3Dka4wp%26page%3Dka4wp_settings&ni=true
@@ -74,6 +74,17 @@ For basic usage, have a look at the [plugin's website](https://kulturwunsch.de/)
 6. Display existing partners as grid via shortcode.
 
 == Changelog ==
+
+= 1.3.2 =
+
+- temp files upload Folder will be deleted on uninstallation
+- temp file while CF7 processing will be stored correctly; and full deleted after finish processing
+- CF7 nonce was removed because it's never been successful (Server side method call)
+- improve WUNSCH.events api definitions
+- fix some minor php bugs
+
+= 1.3.1 =
+- minor code improvments; non functional releas
 
 = 1.3.0 =
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -32,6 +32,17 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 	if(empty(get_option('ka4wp_prevent_deletion')))
 	{
+		//delete temp uploads directory
+		if( !class_exists( 'WP_Filesystem_Direct' ) ) {
+
+            require ABSPATH.'/wp-admin/includes/class-wp-filesystem-base.php';
+            require ABSPATH.'/wp-admin/includes/class-wp-filesystem-direct.php';
+        }
+		$uploadDir = wp_upload_dir();
+		
+		$wpsf = new WP_Filesystem_Direct(false);
+		$wpsf->delete(trailingslashit($uploadDir['basedir']).'ka4wp_temp', true, 'd');
+		
 		//define settings
 		$settingOptions = array('ka4wp_plugin_version', 'ka4wp_installation_id', 'ka4wp_api_receive_eventcategories', 'ka4wp_api_receive_eventcategories_recurrence', 'ka4wp_api_keep_deleted_eventcategories', 'ka4wp_api_receive_impartingareas', 'ka4wp_api_receive_impartingareas_recurrence', 'ka4wp_api_keep_deleted_impartingareas', 'ka4wp_api_receive_partners', 'ka4wp_api_receive_partners_recurrence', 'ka4wp_api_keep_deleted_partners', 'ka4wp_prevent_deletion', 'ka4wp_partnerlogo_default');
 


### PR DESCRIPTION
- temp files upload Folder will be deleted on uninstallation
- temp file while CF7 processing will be stored correctly; and full deleted after finish processing
- cleanup temp folder (delete all files inside)
- CF7 nonce was removed because it's never been successful (Server side method call)
- improve WUNSCH.events api definitions
- fix some minor php bugs