### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 
 name: Deploy to WordPress.org Repository
+permissions:
+  contents: write
 on:
 
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Continious Integration 
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kulturwunsch/Kultur-API-for-WP/security/code-scanning/4](https://github.com/kulturwunsch/Kultur-API-for-WP/security/code-scanning/4)

To fix this, explicitly declare restricted `GITHUB_TOKEN` permissions in the workflow. Since none of the jobs perform operations that require write access to repository contents (they only check out code, install PHP and Composer, run analysis, and minify files within the runner), the minimal and correct fix is to set `permissions: contents: read` at the top level of the workflow. This applies to all jobs (`matrixtest`, `unittest`, and `build`), satisfies CodeQL’s recommendation, and documents the intended least-privilege behavior.

Concretely:
- Edit `.github/workflows/test.yml`.
- Add a `permissions:` block immediately after the `name:` line (or anywhere at the root level alongside `on:` and `jobs:`).
- Set `contents: read` as the only permission, since no write scopes are required by the shown steps.
- No imports or extra code are needed; this is purely a YAML config change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
